### PR TITLE
3.1 Queue Custom Implementation

### DIFF
--- a/QueueCustomImplementation/AlternativeQueue.cs
+++ b/QueueCustomImplementation/AlternativeQueue.cs
@@ -1,0 +1,66 @@
+﻿using QueueCustomImplementation.Interfaces;
+
+namespace QueueCustomImplementation
+{
+    public class AlternativeQueue<T> : IGenericQueue<T>
+    {
+        private int _elementCount = 0;
+        private int _maxCapacity;
+        private T[] _elements;
+
+        public AlternativeQueue(int initialCapacity)
+        {
+            _maxCapacity = initialCapacity;
+            _elements = new T[initialCapacity];
+        }
+
+        public IGenericQueue<T> Clone()
+        {
+            var clonnedQueue = new AlternativeQueue<T>(_maxCapacity);
+            clonnedQueue._elementCount = _elementCount;
+
+            for (int i = 0; i < _maxCapacity; i++)
+            {
+                clonnedQueue._elements[i] = _elements[i];
+            }
+
+            return clonnedQueue;
+        }
+
+        public T Dequeue()
+        {
+            if(_elementCount == 0)
+            {
+                throw new InvalidOperationException("Queue is empty.");
+            }
+
+            var headValue = _elements[0];
+
+            for (int i = 0; i < _elementCount - 1; i++)
+            {
+                _elements[i] = _elements[i + 1];
+            }
+
+            _elements[_maxCapacity - 1] = default!;
+            _elementCount--;
+
+            return headValue;
+        }
+
+        public void Enqueue(T item)
+        {
+            if (_elementCount == _maxCapacity)
+            {
+                throw new InvalidOperationException("The queue is full.");
+            }
+
+            _elements[_elementCount] = item;
+            _elementCount++;
+        }
+
+        public bool IsEmpty()
+        {
+            return _elementCount == 0;
+        }
+    }
+}

--- a/QueueCustomImplementation/Extensions/QueueExtentions.cs
+++ b/QueueCustomImplementation/Extensions/QueueExtentions.cs
@@ -1,0 +1,27 @@
+﻿using QueueCustomImplementation.Interfaces;
+
+namespace QueueCustomImplementation.Extensions
+{
+    public static class QueueExtentions
+    {
+        public static IGenericQueue<T> Tail<T>(this IGenericQueue<T> originalQueue)
+        {
+            var clonedQueue = originalQueue.Clone();
+            var tailQueue = new Queue<T>(clonedQueue.Count() - 1);
+
+            if(clonedQueue.IsEmpty())
+            {
+                return tailQueue;
+            }
+
+            clonedQueue.Drop();
+
+            while(!clonedQueue.IsEmpty())
+            {
+                tailQueue.Enqueue(clonedQueue.Dequeue());
+            }
+
+            return tailQueue;
+        }
+    }
+}

--- a/QueueCustomImplementation/Extensions/QueueExtentions.cs
+++ b/QueueCustomImplementation/Extensions/QueueExtentions.cs
@@ -6,20 +6,9 @@ namespace QueueCustomImplementation.Extensions
     {
         public static IGenericQueue<T> Tail<T>(this IGenericQueue<T> originalQueue)
         {
-            var clonedQueue = originalQueue.Clone();
-            var tailQueue = new Queue<T>(clonedQueue.Count() - 1);
-
-            if(clonedQueue.IsEmpty())
-            {
-                return tailQueue;
-            }
-
-            clonedQueue.Drop();
-
-            while(!clonedQueue.IsEmpty())
-            {
-                tailQueue.Enqueue(clonedQueue.Dequeue());
-            }
+            var tailQueue = originalQueue.Clone();
+            
+            tailQueue.Dequeue();
 
             return tailQueue;
         }

--- a/QueueCustomImplementation/Interfaces/IGenericQueue.cs
+++ b/QueueCustomImplementation/Interfaces/IGenericQueue.cs
@@ -4,7 +4,6 @@
     {
         IGenericQueue<T> Clone();
         T Dequeue();
-        void Drop();
         int Count();
         void Enqueue(T item);
         bool IsEmpty();

--- a/QueueCustomImplementation/Interfaces/IGenericQueue.cs
+++ b/QueueCustomImplementation/Interfaces/IGenericQueue.cs
@@ -1,6 +1,6 @@
 ﻿namespace QueueCustomImplementation.Interfaces
 {
-    public interface IGenericQueue<T>
+    public interface IGenericQueue<T> where T : struct
     {
         IGenericQueue<T> Clone();
         T Dequeue();

--- a/QueueCustomImplementation/Interfaces/IGenericQueue.cs
+++ b/QueueCustomImplementation/Interfaces/IGenericQueue.cs
@@ -1,0 +1,12 @@
+﻿namespace QueueCustomImplementation.Interfaces
+{
+    public interface IGenericQueue<T>
+    {
+        IGenericQueue<T> Clone();   // Used to work with cloned queue in Tail() so the original queue will stay intact
+        T Dequeue();    // Wasn't sure if when removing an element /as in build-in Queue/, it should be returned, or just removed. So this method returns and removes the element 
+        void Drop();    // Just removes the first item /as explained in the task/
+        int Count();     // Used for creating new Queue<T> in Tail() with one less element, since we work with abstraction and can't access [Queue].Elements.Lenght, or _elementCount
+        void Enqueue(T item);
+        bool IsEmpty();
+    }
+}

--- a/QueueCustomImplementation/Interfaces/IGenericQueue.cs
+++ b/QueueCustomImplementation/Interfaces/IGenericQueue.cs
@@ -2,10 +2,10 @@
 {
     public interface IGenericQueue<T>
     {
-        IGenericQueue<T> Clone();   // Used to work with cloned queue in Tail() so the original queue will stay intact
-        T Dequeue();    // Wasn't sure if when removing an element /as in build-in Queue/, it should be returned, or just removed. So this method returns and removes the element 
-        void Drop();    // Just removes the first item /as explained in the task/
-        int Count();     // Used for creating new Queue<T> in Tail() with one less element, since we work with abstraction and can't access [Queue].Elements.Lenght, or _elementCount
+        IGenericQueue<T> Clone();
+        T Dequeue();
+        void Drop();
+        int Count();
         void Enqueue(T item);
         bool IsEmpty();
     }

--- a/QueueCustomImplementation/Interfaces/IGenericQueue.cs
+++ b/QueueCustomImplementation/Interfaces/IGenericQueue.cs
@@ -4,7 +4,6 @@
     {
         IGenericQueue<T> Clone();
         T Dequeue();
-        int Count();
         void Enqueue(T item);
         bool IsEmpty();
     }

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -26,12 +26,12 @@ namespace QueueCustomImplementation
             Console.WriteLine($"Queue after Tail(): {tailQueue}");
             Console.WriteLine($"Original unchanged queue: {queue}");
 
-            Console.WriteLine("Going above max capacity, exception is thrown: ");
-            queue.Enqueue(8);
+            //Console.WriteLine("Going above max capacity, exception is thrown: ");
+            //queue.Enqueue(8);
 
-            Console.Write("Dequeue from empty queue, exception is thrown: ");
-            var emptyQueue = new Queue<string>(1);
-            emptyQueue.Dequeue();
+            //Console.Write("Dequeue from empty queue, exception is thrown: ");
+            //var emptyQueue = new Queue<string>(1);
+            //emptyQueue.Dequeue();
         }
     }
 }

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -26,12 +26,12 @@ namespace QueueCustomImplementation
             Console.WriteLine($"Queue after Tail(): {tailQueue}");
             Console.WriteLine($"Original unchanged queue: {queue}");
 
-            //Console.WriteLine("Going above max capacity, exception is thrown: ");
-            //queue.Enqueue(8);
+            Console.WriteLine("Going above max capacity, exception is thrown: ");
+            queue.Enqueue(8);
 
-            //Console.Write("Dequeue from empty queue, exception is thrown: ");
-            //var emptyQueue = new Queue<string>(1);
-            //emptyQueue.Dequeue();
+            Console.Write("Dequeue from empty queue, exception is thrown: ");
+            var emptyQueue = new Queue<string>(1);
+            emptyQueue.Dequeue();
         }
     }
 }

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -19,7 +19,7 @@ namespace QueueCustomImplementation
 
             queue.Enqueue(5);
             queue.Enqueue(6);
-            
+
             Console.WriteLine($"After Increasing size to maximum: {queue}");
 
             var tailQueue = queue.Tail();
@@ -32,6 +32,16 @@ namespace QueueCustomImplementation
             Console.Write("Dequeue from empty queue, exception is thrown: ");
             var emptyQueue = new Queue<string>(1);
             emptyQueue.Dequeue();
+
+            var alternativeQueue = new AlternativeQueue<int>(5);
+            alternativeQueue.Enqueue(1);
+            alternativeQueue.Enqueue(2);
+            alternativeQueue.Enqueue(3);
+            alternativeQueue.Enqueue(4);
+            alternativeQueue.Enqueue(5);
+            alternativeQueue.Dequeue();
+            alternativeQueue.Enqueue(5);
+            var tail = alternativeQueue.Tail();
         }
     }
 }

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -30,12 +30,12 @@ namespace QueueCustomImplementation
             Console.WriteLine($"Queue after Tail(): {tailQueue}");
             Console.WriteLine($"Original unchanged queue: {queue}");
 
-            Console.WriteLine("Going above max capacity: ");    
-            queue.Enqueue(8);   // -> exception is thrown
+            Console.WriteLine("Going above max capacity, exception is thrown: ");    
+            queue.Enqueue(8);
 
-            Console.Write("Dequeue from empty queue: ");
+            Console.Write("Dequeue from empty queue, exception is thrown: ");
             var emptyQueue = new Queue<string>(1);
-            emptyQueue.Dequeue();   // -> exception is thrown
+            emptyQueue.Dequeue();
         }
     }
 }

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -1,0 +1,41 @@
+﻿using QueueCustomImplementation.Extensions;
+
+namespace QueueCustomImplementation
+{
+    internal class Program
+    {
+        static void Main(string[] args)
+        {
+            var queue = new Queue<int>(5);
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+            queue.Enqueue(3);
+            queue.Enqueue(4);
+            Console.WriteLine($"Original queue: {queue}");
+
+            queue.Drop();
+            Console.WriteLine($"After Drop(): {queue}");
+
+            Console.WriteLine($"Head element value after Dequeue(): {queue.Dequeue()}");
+
+            Console.WriteLine($"The queue is empty: {queue.IsEmpty()}");
+
+            queue.Enqueue(5);
+            queue.Enqueue(6);
+            queue.Enqueue(7);
+            
+            Console.WriteLine($"After Increasing size to maximum: {queue}");
+
+            var tailQueue = queue.Tail();
+            Console.WriteLine($"Queue after Tail(): {tailQueue}");
+            Console.WriteLine($"Original unchanged queue: {queue}");
+
+            Console.WriteLine("Going above max capacity: ");    
+            queue.Enqueue(8);   // -> exception is thrown
+
+            Console.Write("Dequeue from empty queue: ");
+            var emptyQueue = new Queue<string>(1);
+            emptyQueue.Dequeue();   // -> exception is thrown
+        }
+    }
+}

--- a/QueueCustomImplementation/Program.cs
+++ b/QueueCustomImplementation/Program.cs
@@ -13,16 +13,12 @@ namespace QueueCustomImplementation
             queue.Enqueue(4);
             Console.WriteLine($"Original queue: {queue}");
 
-            queue.Drop();
-            Console.WriteLine($"After Drop(): {queue}");
-
             Console.WriteLine($"Head element value after Dequeue(): {queue.Dequeue()}");
 
             Console.WriteLine($"The queue is empty: {queue.IsEmpty()}");
 
             queue.Enqueue(5);
             queue.Enqueue(6);
-            queue.Enqueue(7);
             
             Console.WriteLine($"After Increasing size to maximum: {queue}");
 
@@ -30,7 +26,7 @@ namespace QueueCustomImplementation
             Console.WriteLine($"Queue after Tail(): {tailQueue}");
             Console.WriteLine($"Original unchanged queue: {queue}");
 
-            Console.WriteLine("Going above max capacity, exception is thrown: ");    
+            Console.WriteLine("Going above max capacity, exception is thrown: ");
             queue.Enqueue(8);
 
             Console.Write("Dequeue from empty queue, exception is thrown: ");

--- a/QueueCustomImplementation/Queue.cs
+++ b/QueueCustomImplementation/Queue.cs
@@ -55,11 +55,6 @@ namespace QueueCustomImplementation
             _elementCount++;
         }
 
-        public int Count()
-        {
-            return _elementCount;
-        }
-
         public bool IsEmpty()
         {
             return _elementCount == 0;

--- a/QueueCustomImplementation/Queue.cs
+++ b/QueueCustomImplementation/Queue.cs
@@ -46,7 +46,7 @@ namespace QueueCustomImplementation
             }
             else
             {
-                if (_elementCount <= _initialCapacity)
+                if (_elementCount < _initialCapacity)
                 {
                     _elements[_elementCount] = item;
                 }

--- a/QueueCustomImplementation/Queue.cs
+++ b/QueueCustomImplementation/Queue.cs
@@ -1,0 +1,92 @@
+﻿using QueueCustomImplementation.Interfaces;
+
+namespace QueueCustomImplementation
+{
+    public class Queue<T> : IGenericQueue<T>
+    {
+        private int _elementCount;
+        private int _maxCapacity;
+        private T[] _elements;
+
+        public Queue(int queueElementsCapacity)
+        {
+            _maxCapacity = queueElementsCapacity;
+            _elements = new T[_maxCapacity];
+            _elementCount = 0;
+        }
+
+        public T Dequeue()
+        {
+            var firstItem = _elements[0];
+
+            Drop();
+
+            return firstItem;
+        }
+
+        public void Drop()
+        {
+            if (IsEmpty())
+            {
+                throw new InvalidOperationException("Queue is empty.");
+            }
+
+            var newElements = new T[_elementCount - 1];
+            Array.Copy(_elements, 1, newElements, 0, _elementCount - 1);
+            _elements = newElements;
+            _elementCount--;
+        }
+
+        public void Enqueue(T item)
+        {
+            if (_elementCount == _maxCapacity)
+            {
+                throw new InvalidOperationException("The queue is full.");
+            }
+
+            IncreaseArraySize();
+            _elements[_elementCount++] = item;
+        }
+
+        public int Count()
+        {
+            return _elementCount;
+        }
+
+        public bool IsEmpty()
+        {
+            return _elementCount == 0;
+        }
+
+        public override string ToString()
+        {
+            var result = "";
+
+            foreach (var item in _elements)
+            {
+                result += item is not null ? item.ToString() : "";
+            }
+
+            return result;
+        }
+
+        public IGenericQueue<T> Clone()
+        {
+            var clonedQueue = new Queue<T>(_maxCapacity);
+
+            foreach (var item in _elements)
+            {
+                clonedQueue.Enqueue(item);
+            }
+
+            return clonedQueue;
+        }
+
+        private void IncreaseArraySize()
+        {
+            var newArray = new T[_elementCount + 1];
+            Array.Copy(_elements, newArray, _elementCount);
+            _elements = newArray;
+        }
+    }
+}

--- a/QueueCustomImplementation/Queue.cs
+++ b/QueueCustomImplementation/Queue.cs
@@ -37,7 +37,7 @@ namespace QueueCustomImplementation
                 throw new InvalidOperationException("The queue is full.");
             }
 
-            if (_headPosition >= _initialCapacity)
+            if (_headPosition == _initialCapacity)
             {
                 if (_initialCapacity + _elementCount < _initialCapacity * 2)
                 {
@@ -46,7 +46,7 @@ namespace QueueCustomImplementation
             }
             else
             {
-                if (_elementCount < _initialCapacity)
+                if (_elementCount <= _initialCapacity)
                 {
                     _elements[_elementCount] = item;
                 }

--- a/QueueCustomImplementation/QueueCustomImplementation.csproj
+++ b/QueueCustomImplementation/QueueCustomImplementation.csproj
@@ -1,0 +1,10 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/QueueCustomImplementationTests/AlternativeQueueTests.cs
+++ b/QueueCustomImplementationTests/AlternativeQueueTests.cs
@@ -1,0 +1,95 @@
+﻿using QueueCustomImplementation;
+using QueueCustomImplementation.Extensions;
+
+namespace QueueCustomImplementationTests
+{
+    [TestClass]
+    public class AlternativeQueueTests
+    {
+        [TestMethod]
+        public void EnqueueDequeueSuccess()
+        {
+            var queue = new AlternativeQueue<char>(3);
+            queue.Enqueue('a');
+            queue.Enqueue('b');
+            queue.Enqueue('c');
+
+            Assert.AreEqual('a', queue.Dequeue());
+            Assert.AreEqual('b', queue.Dequeue());
+            Assert.AreEqual('c', queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void EnqueueFailure()
+        {
+            var queue = new AlternativeQueue<int>(2);
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+
+            Assert.ThrowsException<InvalidOperationException>(() => queue.Enqueue(3));
+        }
+
+        [TestMethod]
+        public void DequeueFailure()
+        {
+            var queue = new AlternativeQueue<int>(1);
+
+            Assert.ThrowsException<InvalidOperationException>(() => queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void IsEmptyPossitive()
+        {
+            var queue = new AlternativeQueue<int>(2);
+
+            Assert.IsTrue(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void IsEmptyNegative()
+        {
+            var queue = new AlternativeQueue<int>(2);
+            queue.Enqueue(1);
+
+            Assert.IsFalse(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void CloneSuccess()
+        {
+            var originalQueue = new AlternativeQueue<int>(2);
+            originalQueue.Enqueue(1);
+            originalQueue.Enqueue(2);
+
+            var cloned = originalQueue.Clone();
+
+            Assert.IsNotNull(cloned);
+            Assert.AreNotSame(cloned, originalQueue);
+
+            while (!cloned.IsEmpty())
+            {
+                Assert.AreEqual(cloned.Dequeue(), originalQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void TailSuccess()
+        {
+            var originalQueue = new AlternativeQueue<int>(2);
+            originalQueue.Enqueue(1);
+            originalQueue.Enqueue(2);
+
+            var tailQueue = originalQueue.Tail();
+
+            Assert.IsNotNull(tailQueue);
+            Assert.AreNotSame(tailQueue, originalQueue);
+
+            originalQueue.Dequeue();
+
+            while (!tailQueue.IsEmpty())
+            {
+                Assert.AreEqual(tailQueue.Dequeue(), originalQueue.Dequeue());
+            }
+        }
+    }
+}

--- a/QueueCustomImplementationTests/QueueCustomImplementationTests.csproj
+++ b/QueueCustomImplementationTests/QueueCustomImplementationTests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="6.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\QueueCustomImplementation\QueueCustomImplementation.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
+  </ItemGroup>
+
+</Project>

--- a/QueueCustomImplementationTests/QueueTests.cs
+++ b/QueueCustomImplementationTests/QueueTests.cs
@@ -30,14 +30,6 @@ namespace QueueCustomImplementationTests
         }
 
         [TestMethod]
-        public void DropFailure()
-        {
-            var queue = new QueueCustomImplementation.Queue<int>(1);
-
-            Assert.ThrowsException<InvalidOperationException>(() => queue.Drop());
-        }
-
-        [TestMethod]
         public void DequeueFailure()
         {
             var queue = new QueueCustomImplementation.Queue<int>(1);
@@ -113,7 +105,7 @@ namespace QueueCustomImplementationTests
             Assert.IsNotNull(tailQueue);
             Assert.AreNotSame(tailQueue, originalQueue);
 
-            originalQueue.Drop();
+            originalQueue.Dequeue();
 
             while (!tailQueue.IsEmpty())
             {

--- a/QueueCustomImplementationTests/QueueTests.cs
+++ b/QueueCustomImplementationTests/QueueTests.cs
@@ -1,0 +1,125 @@
+using QueueCustomImplementation.Extensions;
+using System.Runtime.InteropServices;
+
+namespace QueueCustomImplementationTests
+{
+    [TestClass]
+    public class QueueTests
+    {
+        [TestMethod]
+        public void EnqueueDequeueSuccess()
+        {
+            var queue = new QueueCustomImplementation.Queue<char>(3);
+            queue.Enqueue('a');
+            queue.Enqueue('b');
+            queue.Enqueue('c');
+
+            // No other way to access the Elements
+            Assert.AreEqual('a', queue.Dequeue());
+            Assert.AreEqual('b', queue.Dequeue());
+            Assert.AreEqual('c', queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void EnqueueFailure()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(2);
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+
+            Assert.ThrowsException<InvalidOperationException>(() => queue.Enqueue(3));
+        }
+
+        [TestMethod]
+        public void DropFailure()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(1);
+
+            Assert.ThrowsException<InvalidOperationException>(() => queue.Drop());
+        }
+
+        [TestMethod]
+        public void DequeueFailure()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(1);
+
+            Assert.ThrowsException<InvalidOperationException>(() => queue.Dequeue());
+        }
+
+        [TestMethod]
+        public void CountSuccess()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(2);
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+
+            Assert.AreEqual(2, queue.Count());
+        }
+
+        [TestMethod]
+        public void IsEmptyPossitive()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(2);
+
+            Assert.IsTrue(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void IsEmptyNegative()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(2);
+            queue.Enqueue(1);
+
+            Assert.IsFalse(queue.IsEmpty());
+        }
+
+        [TestMethod]
+        public void ToStringOverrideSuccess()
+        {
+            var queue = new QueueCustomImplementation.Queue<int>(3);
+            queue.Enqueue(1);
+            queue.Enqueue(2);
+            queue.Enqueue(3);
+
+            Assert.AreEqual("123", queue.ToString());
+        }
+
+        [TestMethod]
+        public void CloneSuccess()
+        {
+            var originalQueue = new QueueCustomImplementation.Queue<int>(2);
+            originalQueue.Enqueue(1);
+            originalQueue.Enqueue(2);
+
+            var cloned = originalQueue.Clone();
+
+            Assert.IsNotNull(cloned);
+            Assert.AreNotSame(cloned, originalQueue);
+
+            while(!cloned.IsEmpty())
+            {
+                Assert.AreEqual(cloned.Dequeue(), originalQueue.Dequeue());
+            }
+        }
+
+        [TestMethod]
+        public void TailSuccess()
+        {
+            var originalQueue = new QueueCustomImplementation.Queue<int>(2);
+            originalQueue.Enqueue(1);
+            originalQueue.Enqueue(2);
+
+            var tailQueue = originalQueue.Tail();
+
+            Assert.IsNotNull(tailQueue);
+            Assert.AreNotSame(tailQueue, originalQueue);
+
+            originalQueue.Drop();
+
+            while (!tailQueue.IsEmpty())
+            {
+                Assert.AreEqual(tailQueue.Dequeue(), originalQueue.Dequeue());
+            }
+        }
+    }
+}

--- a/QueueCustomImplementationTests/QueueTests.cs
+++ b/QueueCustomImplementationTests/QueueTests.cs
@@ -38,16 +38,6 @@ namespace QueueCustomImplementationTests
         }
 
         [TestMethod]
-        public void CountSuccess()
-        {
-            var queue = new QueueCustomImplementation.Queue<int>(2);
-            queue.Enqueue(1);
-            queue.Enqueue(2);
-
-            Assert.AreEqual(2, queue.Count());
-        }
-
-        [TestMethod]
         public void IsEmptyPossitive()
         {
             var queue = new QueueCustomImplementation.Queue<int>(2);

--- a/QueueCustomImplementationTests/QueueTests.cs
+++ b/QueueCustomImplementationTests/QueueTests.cs
@@ -14,7 +14,6 @@ namespace QueueCustomImplementationTests
             queue.Enqueue('b');
             queue.Enqueue('c');
 
-            // No other way to access the Elements
             Assert.AreEqual('a', queue.Dequeue());
             Assert.AreEqual('b', queue.Dequeue());
             Assert.AreEqual('c', queue.Dequeue());

--- a/dotNetSchool.sln
+++ b/dotNetSchool.sln
@@ -10,17 +10,24 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Task2", "Task2", "{1FCC0111-28AC-4301-BE62-D714DB3FC7C6}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Task3", "Task3", "{9EE23B8E-EDEF-4D18-8B3F-98485CB48B20}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Task2", "Task2", "{6A84DD99-8A2B-456A-B082-41C707618FB1}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Homework2", "Homework2", "{491FD4A3-C1BB-413B-B71C-AC5AE529FC5B}"
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagonalMatrix", "DiagonalMatrix\DiagonalMatrix.csproj", "{8A92B580-596C-459E-9073-DBBF7D1D81E6}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DiagonalMatrixTests", "DiagonalMatrixTests\DiagonalMatrixTests.csproj", "{E5D523ED-E6AD-4CD3-ACCD-6487AF39A15E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiagonalMatrix", "DiagonalMatrix\DiagonalMatrix.csproj", "{8A92B580-596C-459E-9073-DBBF7D1D81E6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "DiagonalMatrixTests", "DiagonalMatrixTests\DiagonalMatrixTests.csproj", "{E5D523ED-E6AD-4CD3-ACCD-6487AF39A15E}"
+EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Task1", "Task1", "{B2EA64EA-CEC9-42A1-BD54-FA0CB08694F2}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlanetariumOnTheComputer", "PlanetariumOnTheComputer\PlanetariumOnTheComputer.csproj", "{7730C561-721F-476C-A13C-4E391109FDD3}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PlanetariumOnTheComputerTests", "PlanetariumOnTheComputerTests\PlanetariumOnTheComputerTests.csproj", "{A050A2F1-6584-4837-96C4-CFE7667A837B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "PlanetariumOnTheComputerTests", "PlanetariumOnTheComputerTests\PlanetariumOnTheComputerTests.csproj", "{A050A2F1-6584-4837-96C4-CFE7667A837B}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueueCustomImplementation", "QueueCustomImplementation\QueueCustomImplementation.csproj", "{5213051B-7681-40E8-B7A8-03879660F933}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "QueueCustomImplementationTests", "QueueCustomImplementationTests\QueueCustomImplementationTests.csproj", "{9EF67E2D-0243-4FAC-A6C2-E4D6746EDDD8}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -28,14 +35,6 @@ Global
 		Release|Any CPU = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{7730C561-721F-476C-A13C-4E391109FDD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{7730C561-721F-476C-A13C-4E391109FDD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{7730C561-721F-476C-A13C-4E391109FDD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{7730C561-721F-476C-A13C-4E391109FDD3}.Release|Any CPU.Build.0 = Release|Any CPU
-		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Release|Any CPU.Build.0 = Release|Any CPU
 		{8A92B580-596C-459E-9073-DBBF7D1D81E6}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{8A92B580-596C-459E-9073-DBBF7D1D81E6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8A92B580-596C-459E-9073-DBBF7D1D81E6}.Release|Any CPU.ActiveCfg = Release|Any CPU
@@ -44,6 +43,22 @@ Global
 		{E5D523ED-E6AD-4CD3-ACCD-6487AF39A15E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E5D523ED-E6AD-4CD3-ACCD-6487AF39A15E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E5D523ED-E6AD-4CD3-ACCD-6487AF39A15E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7730C561-721F-476C-A13C-4E391109FDD3}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7730C561-721F-476C-A13C-4E391109FDD3}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7730C561-721F-476C-A13C-4E391109FDD3}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7730C561-721F-476C-A13C-4E391109FDD3}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A050A2F1-6584-4837-96C4-CFE7667A837B}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5213051B-7681-40E8-B7A8-03879660F933}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5213051B-7681-40E8-B7A8-03879660F933}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5213051B-7681-40E8-B7A8-03879660F933}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5213051B-7681-40E8-B7A8-03879660F933}.Release|Any CPU.Build.0 = Release|Any CPU
+		{9EF67E2D-0243-4FAC-A6C2-E4D6746EDDD8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{9EF67E2D-0243-4FAC-A6C2-E4D6746EDDD8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{9EF67E2D-0243-4FAC-A6C2-E4D6746EDDD8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{9EF67E2D-0243-4FAC-A6C2-E4D6746EDDD8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
1. I was not sure if the Dequeue method is supposed just to remove the head element /as explained in the task/, or remove and return it /as the build-in queue works/, so I provided you with two methods: Drop() - just removes, Dequeue removes and returns the element. 
2. Implemented a few extra methods needed for the solution of the task in the interface since we are working with abstraction and cannot access properties and class methods directly, hope it is not a problem:
    -> Count() - returning the number of elements in the queue
    -> Clone() - for creating a clone of the queue used in the Tail() method, so this way we will work with a clone and won't affect the original queue, provided as parameter. Since the only way to extract a value out of queue is by Dequeue() /not mentioning Peek() since it does not work in this case/ and that would affect the original queue /reference type/